### PR TITLE
[Easy] Rename usd_gno to usd_6810e776880c02933d47db1b9fc05908e5386b96

### DIFF
--- a/gnosis_protocol/liquidity_provision/2020_09_01_stablecoin_liquidity_round_4.sql
+++ b/gnosis_protocol/liquidity_provision/2020_09_01_stablecoin_liquidity_round_4.sql
@@ -264,7 +264,7 @@ returns as(
 ),
 last_gno_price as (
     SELECT price 
-    FROM prices."usd_gno"
+    FROM prices."usd_6810e776880c02933d47db1b9fc05908e5386b96"
     ORDER BY minute DESC
     LIMIT 1
 ),


### PR DESCRIPTION
They changed the token symbol name to token addresses (presumably to avoid duplicates).